### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: "Docker"
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: ["master"]
+
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          load: true
+          tags: "dockette/gruntz:latest"
+
+      - name: "Test image"
+        run: "make test"
+
+  build:
+    name: "Build"
+    needs: ["test"]
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/gruntz"
+      tag: "latest"
+      platforms: "linux/amd64"
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/gruntz"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,21 @@
+# AGENTS.md
+
+## Repository
+
+`dockette/gruntz` is a legacy Docker image for running the Windows game Gruntz through Wine.
+
+## Scope
+
+- Keep changes focused on image buildability, smoke checks, and documentation.
+- Treat this as a GUI/game image; do not try to run the full interactive game in CI.
+- Prefer non-interactive validation such as Wine version checks and packaged binary presence.
+
+## Commands
+
+- `make build` builds `dockette/gruntz:${DOCKER_TAG}` for `${DOCKER_PLATFORMS}`.
+- `make test` runs smoke checks against the built image.
+- `make run` starts the GUI container with X11 and sound mounts for local/manual testing.
+
+## CI
+
+The Docker workflow has Test, Build, and Docs jobs. The default build platform is `linux/amd64` because the image depends on Wine and a legacy GUI runtime.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+DOCKER_IMAGE=dockette/gruntz
+DOCKER_TAG?=latest
+DOCKER_PLATFORMS?=linux/amd64
+
+.PHONY: build
+build:
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+
+.PHONY: test
+test:
+	docker run --rm --entrypoint sh ${DOCKER_IMAGE}:${DOCKER_TAG} -lc 'wine --version'
+	docker run --rm --entrypoint sh ${DOCKER_IMAGE}:${DOCKER_TAG} -lc 'test -f /srv/gruntz/GRUNTZ.exe'
+
+.PHONY: run
+run:
+	docker run --rm -it -v /tmp/.X11-unix:/tmp/.X11-unix:ro -e DISPLAY=$$DISPLAY --device /dev/snd -v /dev/shm:/dev/shm ${DOCKER_IMAGE}:${DOCKER_TAG}

--- a/README.md
+++ b/README.md
@@ -1,31 +1,58 @@
-# Gruntz
+<h1 align=center>Dockette / Gruntz</h1>
 
-Famous old school game (https://en.wikipedia.org/wiki/Gruntz).
+<p align=center>
+   <a href="https://github.com/dockette/gruntz/actions"><img src="https://github.com/dockette/gruntz/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/gruntz"><img src="https://img.shields.io/docker/pulls/dockette/gruntz.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
+   Legacy Docker image for <a href="https://en.wikipedia.org/wiki/Gruntz">Gruntz</a>, an old-school Windows game run through Wine.
+   Maintenance is limited to image buildability and non-interactive smoke checks.
+</p>
+
+-----
+
+## Status
+
+This image is maintained as a legacy GUI/game image. Runtime needs an X11 display, sound device, and manual interaction, so CI validates only the Docker build and packaged binary presence. The Docker Hub badge may be less representative than for headless images because this image is GUI-only and practical usage is local/interactive.
 
 ![Gruntz in Docker container](https://raw.githubusercontent.com/whaleapps/gruntz/master/docs/gruntz.png)
 
 ## Usage
 
-```
+```bash
 docker run \
-	   --rm \
-       -it \
-       -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
-       -e DISPLAY=$DISPLAY \
-       --device /dev/snd \
-       -v /dev/shm:/dev/shm \
-       whaleapps/gruntz
+  --rm \
+  -it \
+  -v /tmp/.X11-unix:/tmp/.X11-unix:ro \
+  -e DISPLAY=$DISPLAY \
+  --device /dev/snd \
+  -v /dev/shm:/dev/shm \
+  dockette/gruntz:latest
 ```
 
 Don't forget to allow xhost.
 
-```
+```bash
 xhost +x
 ```
 
 ## Troubleshooting
 
-Gruntz works only at resolution 640x480.	
+Gruntz works only at resolution 640x480.
+
+## Development
+
+```bash
+make build
+make test
+make run
+```
+
+The `test` target is intentionally limited to non-interactive smoke checks. It verifies Wine is available in the image and that the bundled Gruntz executable exists without trying to start the GUI game.
 
 ## Maintenance
+
 See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.


### PR DESCRIPTION
What changed
- Added a Dockette Docker workflow with Test, Build, and Docs jobs.
- Added Makefile baseline targets for build, smoke-only test, and GUI run.
- Updated README with copybara-style badges, legacy GUI status, and maintenance guidance.
- Added repository AGENTS.md and CLAUDE.md handoff files.

Why
- Gruntz is a legacy Wine/X11 GUI image, so CI should validate image buildability and non-interactive smoke checks without trying to launch the game runtime.